### PR TITLE
redirect-uri 오류해결-2

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
             scope:
               - email
               - profile
-            redirect-uri: "https://{baseHost}{basePort}/login/oauth2/code/google"
+            redirect-uri: "https://port-0-server-lz1cq56f81af005d.sel4.cloudtype.app/login/oauth2/code/google"
 
   datasource:
     url: ${DB_URL}


### PR DESCRIPTION
## Describe
redirect-uri로 인해 뜨는 400오류를 해결하기 위해 redirect-uri를 변경하였습니다.

## Additional
구글 클라우드에서 설정한 redirect-url과 application.ymp에서 설정한 redirect-url을 같도록 맞췄습니다.